### PR TITLE
Muutettu authorin regex sallimaan nimet, joissa yhdysviiva tai heittomerkki

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,4 @@ Ohjelmasta on julkaistu [release](https://github.com/tuomoart/ohtu-miniprojekti-
 ### Ohjelman käyttö
 
 Ohjelman käynnistyttyä avautuu ohjelma "lisää uusi lukuvinkki" -näkymään. Syöttämällä lukuvinkin tiedot voi käyttäjä lisätä uuden vinkin lukuvinkkikirjastoon. Oikeasta ylänurkasta pääsee hakunäkymään painamalla nappia "Hae". Hakunäkymässä käyttäjä voi hakea ja tarkastella omia lukuvinkkejään.
+

--- a/src/main/java/library/domain/Logic.java
+++ b/src/main/java/library/domain/Logic.java
@@ -65,7 +65,7 @@ public class Logic {
     
     public boolean textIsValidAuthorName(String text) {
         if (text.isEmpty()) return true;
-        return text.matches("^[ .A-Öa-ö]+$");
+        return text.matches("^[A-Öa-ö]+((\\s)?((\\'|\\-)?([A-Öa-ö])+))*$"); 
     }
     
     public boolean textIsValidInteger(String text) {


### PR DESCRIPTION
Viikko 6 tehtävä 6 liittyen: Tekijän nimen regex oli aika tiukka, niin muutin siten, että sallii yhdysviivoja ja heittomerkkejä käyttävät nimet.